### PR TITLE
Add constructors to `ResizableVector` & `ResizableMatrix`

### DIFF
--- a/src/ResizableArrays.jl
+++ b/src/ResizableArrays.jl
@@ -152,10 +152,6 @@ ResizableArray{T}(A::AbstractArray) where {T} =
     copyto!(ResizableArray{T}(undef, size(A)), A)
 ResizableArray(A::AbstractArray{T}) where {T} =
     copyto!(ResizableArray{T}(undef, size(A)), A)
-ResizableVector(A::AbstractArray{T}) where {T} =
-    ResizableArray{T,1}(A)
-ResizableMatrix(A::AbstractArray{T}) where {T} =
-    ResizableArray{T,2}(A)
 
 # Constructor for, initially empty, workspace of given rank and element type.
 ResizableArray{T,N}() where {T,N} =
@@ -201,6 +197,8 @@ Alias for [`ResizableArray{T,1}`](@ref).
 
 """
 const ResizableVector{T,B} = ResizableArray{T,1,B}
+ResizableVector(A::AbstractArray{T}) where {T} =
+    ResizableArray{T,1}(A)
 
 """
     ResizableMatrix{T}
@@ -210,6 +208,8 @@ Alias for [`ResizableArray{T,2}`](@ref).
 
 """
 const ResizableMatrix{T,B} = ResizableArray{T,2,B}
+ResizableMatrix(A::AbstractArray{T}) where {T} =
+    ResizableArray{T,2}(A)
 
 """
     ResizableArrays.checksize(dims) -> len

--- a/src/ResizableArrays.jl
+++ b/src/ResizableArrays.jl
@@ -152,10 +152,10 @@ ResizableArray{T}(A::AbstractArray) where {T} =
     copyto!(ResizableArray{T}(undef, size(A)), A)
 ResizableArray(A::AbstractArray{T}) where {T} =
     copyto!(ResizableArray{T}(undef, size(A)), A)
-ResizableVector(A::AbstractVector{T}) where {T} =
-    copyto!(ResizableVector{T}(undef, size(A)), A)
-ResizableMatrix(A::AbstractMatrix{T}) where {T} =
-    copyto!(ResizableMatrix{T}(undef, size(A)), A)
+ResizableVector(A::AbstractArray{T}) where {T} =
+    ResizableArray{T,1}(A)
+ResizableMatrix(A::AbstractArray{T}) where {T} =
+    ResizableArray{T,2}(A)
 
 # Constructor for, initially empty, workspace of given rank and element type.
 ResizableArray{T,N}() where {T,N} =

--- a/src/ResizableArrays.jl
+++ b/src/ResizableArrays.jl
@@ -152,6 +152,10 @@ ResizableArray{T}(A::AbstractArray) where {T} =
     copyto!(ResizableArray{T}(undef, size(A)), A)
 ResizableArray(A::AbstractArray{T}) where {T} =
     copyto!(ResizableArray{T}(undef, size(A)), A)
+ResizableVector(A::AbstractVector{T}) where {T} =
+    copyto!(ResizableVector{T}(undef, size(A)), A)
+ResizableMatrix(A::AbstractMatrix{T}) where {T} =
+    copyto!(ResizableMatrix{T}(undef, size(A)), A)
 
 # Constructor for, initially empty, workspace of given rank and element type.
 ResizableArray{T,N}() where {T,N} =

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -270,9 +270,9 @@ end
 
 @testset "Add new constructors" begin  # See https://github.com/emmt/ResizableArrays.jl/pull/3
     @test ResizableVector(1:3) == ResizableArray(1:3)
-    @test_throws MethodError ResizableVector(rand(2, 4))
+    @test_throws DimensionMismatch ResizableVector(rand(2, 4))
     @test ResizableMatrix(reshape(1:9, 3, 3)) == ResizableArray(reshape(1:9, 3, 3))
-    @test_throws MethodError ResizableMatrix(1:3)
+    @test_throws DimensionMismatch ResizableMatrix(1:3)
 end
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -268,4 +268,11 @@ end
     end
 end
 
+@testset "Add new constructors" begin  # See https://github.com/emmt/ResizableArrays.jl/pull/3
+    @test ResizableVector(1:3) == ResizableArray(1:3)
+    @test_throws MethodError ResizableVector(rand(2, 4))
+    @test ResizableMatrix(reshape(1:9, 3, 3)) == ResizableArray(reshape(1:9, 3, 3))
+    @test_throws MethodError ResizableMatrix(1:3)
+end
+
 end # module


### PR DESCRIPTION
Directly calling

```julia
ResizableVector(A::AbstractVector)
ResizableMatrix(A::AbstractMatrix)
```

will result in errors. I could only do `ResizableVector{eltype(A)}(A)` before. However, it is pretty common to write such constructors intuitively. So I wish to add these constructors for simplicity.